### PR TITLE
fix(account): `Unauthorized` should blacklisted refresh token

### DIFF
--- a/internal/account/api/router/router.go
+++ b/internal/account/api/router/router.go
@@ -23,7 +23,6 @@ func AccountRouter(group *gin.RouterGroup, db *gorm.DB, config *config.Config, r
 	}
 
 	setupAccountRoutes := func(accountGroup *gin.RouterGroup) {
-		accountGroup.Use(middlewareFunc)
 		accountGroup.GET("/me", accountHandler.GetAccountHandler)
 		accountGroup.PATCH("/me/update", accountHandler.UpdateAccountHandler)
 		accountGroup.PUT("/me/update_password", accountHandler.UpdatePasswordAccountHandler)
@@ -32,6 +31,6 @@ func AccountRouter(group *gin.RouterGroup, db *gorm.DB, config *config.Config, r
 	authGroup := group.Group("/auth/account")
 	setupAccountAuthRoutes(authGroup)
 
-	accountGroup := group.Group("/account")
+	accountGroup := group.Group("/account", middlewareFunc)
 	setupAccountRoutes(accountGroup)
 }

--- a/internal/account/api/router/router.go
+++ b/internal/account/api/router/router.go
@@ -18,6 +18,7 @@ func AccountRouter(group *gin.RouterGroup, db *gorm.DB, config *config.Config, r
 		accountAuthGroup.POST("/registration", accountHandler.RegisterAccountHandler)
 		accountAuthGroup.POST("/authorization", accountHandler.AuthHandler)
 		accountAuthGroup.POST("/unauthorization", middlewareFunc, accountHandler.UnauthHandler)
+		// @FIXME: `refresh_token` no need middleware
 		accountAuthGroup.POST("/refresh_token", middlewareFunc, accountHandler.RefreshTokenHandler)
 	}
 

--- a/internal/account/api/types/request.go
+++ b/internal/account/api/types/request.go
@@ -21,8 +21,8 @@ type AccountAuthRequest struct {
 	Password string `json:"password" validate:"required,min=8,max=100"`
 }
 
-// AccountUnauthRefreshRequest represents a request structure for refreshing tokens and account unauthenticated.
-type AccountUnauthRefreshRequest struct {
+// AccountUnauthRequest represents the request payload for unauthenticating an account by invalidating access and refresh tokens.
+type AccountUnauthRequest struct {
 	AccessToken  string `json:"access_token" validate:"required"`
 	RefreshToken string `json:"refresh_token" validate:"required"`
 }
@@ -31,4 +31,9 @@ type AccountUnauthRefreshRequest struct {
 type AccountUpdatePasswordRequest struct {
 	OldPassword string `json:"old_password" validate:"required,min=8,max=100"`
 	NewPassword string `json:"new_password" validate:"required,min=8,max=100"`
+}
+
+// AccountRefreshTokenRequest represents a request to refresh an authentication token for an account.
+type AccountRefreshTokenRequest struct {
+	RefreshToken string `json:"refresh_token" validate:"required"`
 }


### PR DESCRIPTION
# Description

This PR fixing refresh token not blacklisted when access `api/v1/auth/account/unauthorization` & fixing middleware not working at this endpoint.

# Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [x] Chore
- [ ] Bump version
