### PR TITLE
ci(workflows): add no activity workflow

### DIFF
--- a/.github/workflows/no_activity.yaml
+++ b/.github/workflows/no_activity.yaml
@@ -1,7 +1,7 @@
 name: Close inactive issues
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "30 18 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/no_activity.yaml
+++ b/.github/workflows/no_activity.yaml
@@ -19,6 +19,6 @@ jobs:
           stale-issue-label: "stale"
           stale-pr-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 3 weeks since being marked as stale."
+          close-issue-message: "This issue was closed because it has been inactive for 23 days since being marked as stale."
           stale-pr-message: "This pull request is stale because it has been open for 30 days with no activity."
-          close-pr-message: "This pull request was closed because it has been inactive for 3 weeks since being marked as stale."
+          close-pr-message: "This pull request was closed because it has been inactive for 23 days since being marked as stale."

--- a/.github/workflows/no_activity.yaml
+++ b/.github/workflows/no_activity.yaml
@@ -1,0 +1,24 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9.0.0
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 23
+          days-before-pr-stale: 30
+          days-before-pr-close: 23
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 3 weeks since being marked as stale."
+          stale-pr-message: "This pull request is stale because it has been open for 30 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 3 weeks since being marked as stale."


### PR DESCRIPTION
# Description

This PR adds a GitHub Actions workflow that automatically closes inactive issues and pull requests in the repository. The workflow is scheduled to run daily at 18:30 UTC (equivalent to 01:30 GMT+7).

# Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
- [ ] Bump version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow to manage inactive issues and pull requests, improving repository maintenance.
	- Issues and pull requests will be marked as stale after 30 days of inactivity and closed after an additional 23 days.
	- Custom messages and labels for stale and closed items enhance user awareness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->